### PR TITLE
Add support callbacks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,7 +85,34 @@ A debounce delay of 50ms is a safe value; it doesn't hurt the reaction time, and
 ```
 if((newlevel != level) & (millis() - _switchedTime >= debounceDelay))
 ```
-Using an interrupt service routine for polling the buttons
+
+#### Status callbacks 
+
+Callbacks can be used, instead of needing to call `switch.poll()` and then checking with an `if` statement whether the relevant event has occurred. 
+With a callback registered, Switch will run the defined function when the conditions are met. 
+
+Define a function you want to perform, with no return type and no arguments: 
+
+
+```C++
+void foo() {
+	//your code;
+}
+``` 
+and then call one of the four "set callback" methods in setup, like so: 
+
+```C++
+void setup() {
+	...
+	switch.setPushedCallback(&foo);
+	...
+	}
+``` 
+
+There is also `setReleasedCallback`, `setLongPressCallback`, and `setDoubleClickCallback`. If using a toggle switch and not a push button, the "pressed" event will be of interest when the switch is turned on, and "released" when it is turned off. 
+
+
+#### Using an interrupt service routine for polling the buttons
 
 Polling buttons has a high priority, slow functions such as Serial.print() may disrupt the timing. See here how to use an ISR for polling the buttons:
 

--- a/Readme.md
+++ b/Readme.md
@@ -82,7 +82,7 @@ If the above assumptions are met, the software debounce algorithm can be quite s
 
 A debounce delay of 50ms is a safe value; it doesn't hurt the reaction time, and will handle even bad switches. 
 
-```
+```C++
 if((newlevel != level) & (millis() - _switchedTime >= debounceDelay))
 ```
 
@@ -99,14 +99,15 @@ void foo() {
 	//your code;
 }
 ``` 
-and then call one of the four "set callback" methods in setup, like so: 
+and then call one of the four "set callback" methods in the Arduino setup function, like so: 
 
 ```C++
 void setup() {
-	...
+	... // Other setup code 
+	... 
 	switch.setPushedCallback(&foo);
 	...
-	}
+}
 ``` 
 
 There is also `setReleasedCallback`, `setLongPressCallback`, and `setDoubleClickCallback`. If using a toggle switch and not a push button, the "pressed" event will be of interest when the switch is turned on, and "released" when it is turned off. 
@@ -116,7 +117,7 @@ There is also `setReleasedCallback`, `setLongPressCallback`, and `setDoubleClick
 
 Polling buttons has a high priority, slow functions such as Serial.print() may disrupt the timing. See here how to use an ISR for polling the buttons:
 
-```
+```C++
 #include <Arduino.h>
 #include "Switch.h"
 #include <FrequencyTimer2.h>

--- a/Switch.cpp
+++ b/Switch.cpp
@@ -56,10 +56,6 @@ pin(_pin), polarity(polarity), debounceDelay(debounceDelay), longPressDelay(long
 { pinMode(pin, PinMode);
   _switchedTime = millis();
   level = digitalRead(pin);
-  _pushedCallback = 0;
-  _releasedCallback = 0;
-  _longPressCallback = 0;
-  _doubleClickCallback = 0;
 }
 
 bool Switch::poll()

--- a/Switch.cpp
+++ b/Switch.cpp
@@ -56,6 +56,10 @@ pin(_pin), polarity(polarity), debounceDelay(debounceDelay), longPressDelay(long
 { pinMode(pin, PinMode);
   _switchedTime = millis();
   level = digitalRead(pin);
+  _pushedCallback = 0;
+  _releasedCallback = 0;
+  _longPressCallback = 0;
+  _doubleClickCallback = 0;
 }
 
 bool Switch::poll()
@@ -65,6 +69,9 @@ bool Switch::poll()
   if(!_longPressLatch)
   { _longPress = on() && ((long)(millis() - pushedTime) > longPressDelay); // true just one time between polls
     _longPressLatch = _longPress; // will be reset at next switch
+  }
+  if(_longPressCallback && longPress())
+  { _longPressCallback();
   }
 
   if((newlevel != level) & (millis() - _switchedTime >= debounceDelay))
@@ -77,6 +84,17 @@ bool Switch::poll()
     { _doubleClick = (long)(millis() - pushedTime) < doubleClickDelay;
       pushedTime = millis();
     }
+    
+    if(_pushedCallback && pushed())
+    { _pushedCallback();
+	}
+	else if(_releasedCallback && released())
+	{ _releasedCallback();
+	}
+    
+    if(_doubleClickCallback && doubleClick())
+    { _doubleClickCallback();
+	}
     return _switched;
   }
   return _switched = 0;
@@ -108,4 +126,24 @@ bool Switch::doubleClick()
 
 bool Switch::longPressLatch()
 { return _longPressLatch;
+}
+
+void Switch::setPushedCallback(void (*cb)(void))
+{ /// Store the "pushed" callback function
+  _pushedCallback = cb;
+}
+
+void Switch::setReleasedCallback(void (*cb)(void))
+{ /// Store the "released" callback function
+  _releasedCallback = cb;
+}
+
+void Switch::setLongPressCallback(void (*cb)(void))
+{ /// Store the "long press" callback function
+  _longPressCallback = cb;
+}
+
+void Switch::setDoubleClickCallback(void (*cb)(void))
+{ /// Store the "double click" callback function
+  _doubleClickCallback = cb;
 }

--- a/Switch.h
+++ b/Switch.h
@@ -38,10 +38,10 @@ protected:
   bool level, _switched, _longPress, _longPressLatch, _doubleClick;
   
   // Event callbacks
-  void (*_pushedCallback)(void);
-  void (*_releasedCallback)(void);
-  void (*_longPressCallback)(void);
-  void (*_doubleClickCallback)(void);
+  void (*_pushedCallback)(void) = 0;
+  void (*_releasedCallback)(void) = 0;
+  void (*_longPressCallback)(void) = 0;
+  void (*_doubleClickCallback)(void) = 0;
 };
 
 #endif

--- a/Switch.h
+++ b/Switch.h
@@ -24,12 +24,24 @@ public:
   bool doubleClick(); // will be refreshed by poll()
 
   unsigned long _switchedTime, pushedTime;
+  
+  // Set methods for event callbacks 
+  void setPushedCallback(void (*cb)(void));
+  void setReleasedCallback(void (*cb)(void));
+  void setLongPressCallback(void (*cb)(void));
+  void setDoubleClickCallback(void (*cb)(void));
 
 protected:
   const byte pin;
   const int debounceDelay, longPressDelay, doubleClickDelay;
   const bool polarity;
   bool level, _switched, _longPress, _longPressLatch, _doubleClick;
+  
+  // Event callbacks
+  void (*_pushedCallback)(void);
+  void (*_releasedCallback)(void);
+  void (*_longPressCallback)(void);
+  void (*_doubleClickCallback)(void);
 };
 
 #endif


### PR DESCRIPTION
This pull request adds some basic support for callback functions. This means the when `switch.poll()` is called, if any of the "pushed", "released", "long press" or "double click" events have been detected in that polling loop the relevant callback function will be called. This makes it possible to only have the `switch.poll()` call in the main loop, and no extra `if` logic. 

Also updated the README to reflect the new features. 