### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,13 +9,13 @@ Switch	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-poll KEYWORD2
-switched KEYWORD2
-on KEYWORD2
-pushed KEYWORD2
-released KEYWORD2
-longPress KEYWORD2
-doubleClick KEYWORD2
+poll	KEYWORD2
+switched	KEYWORD2
+on	KEYWORD2
+pushed	KEYWORD2
+released	KEYWORD2
+longPress	KEYWORD2
+doubleClick	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords