### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,7 +4,7 @@ author=Albert van Dalen
 maintainer=Dean Blackketter
 sentence=Arduino library for debouncing switches and buttons
 paragraph=Arduino library for debouncing switches and buttons
-category=Input
+category=Signal Input/Output
 url=https://github.com/blackketter/Switch
 architectures=*
 


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Input' in library Switch is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format